### PR TITLE
Add missing lang entry for potted tiny cactus

### DIFF
--- a/common/src/main/resources/assets/creeperoverhaul/lang/en_us.json
+++ b/common/src/main/resources/assets/creeperoverhaul/lang/en_us.json
@@ -29,6 +29,7 @@
   "entity.creeperoverhaul.snowy_creeper": "Snowy Creeper",
   "item.creeperoverhaul.snowy_creeper_spawn_egg": "Snowy Creeper Spawn Egg",
   "block.creeperoverhaul.tiny_cactus": "Tiny Cactus",
+  "block.creeperoverhaul.potted_tiny_cactus": "Potted Tiny Cactus",
 
   "subtitles.creeperoverhaul.entity.wood.creeper.hit": "Creeper hit",
   "subtitles.creeperoverhaul.entity.wood.creeper.death": "Creeper dies",


### PR DESCRIPTION
This PR add the localized name for the potted tiny cactus. The translated names of blocks without block items are pretty much never used in vanilla, but mods can still get them using Block::getName (All vanilla blocks are translated even if they don't have a corresponding item)