### PR TITLE
Moderate AI Rewite (1.19 Branch)

### DIFF
--- a/common/src/main/java/tech/thatgravyboat/creeperoverhaul/common/entity/CreeperTypes.java
+++ b/common/src/main/java/tech/thatgravyboat/creeperoverhaul/common/entity/CreeperTypes.java
@@ -256,7 +256,7 @@ public class CreeperTypes {
             //.addImmunity(DamageSource.DROWN)
             .addAttribute(Attributes.MAX_HEALTH, 15)
             .addAttribute("swim_speed", 2)
-            .addReplacer(state -> state.is(Blocks.GRASS_BLOCK) || state.is(Blocks.DIRT), random -> random.nextInt(3) == 0 ? Blocks.SAND.defaultBlockState() : null)
+            .addReplacer(state -> state.is(Blocks.GRAVEL) || state.is(Blocks.SAND), random -> random.nextInt(3) == 0 ? Blocks.WATER.defaultBlockState() : null)
             .setDeathSounds(ModSounds.SAND_DEATH)
             .setExplosionSounds(ModSounds.SAND_EXPLOSION)
             .setHurtSounds(ModSounds.SAND_HURT)

--- a/common/src/main/java/tech/thatgravyboat/creeperoverhaul/common/entity/CreeperTypes.java
+++ b/common/src/main/java/tech/thatgravyboat/creeperoverhaul/common/entity/CreeperTypes.java
@@ -2,14 +2,15 @@ package tech.thatgravyboat.creeperoverhaul.common.entity;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
-import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.monster.Stray;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.material.Fluid;
 import tech.thatgravyboat.creeperoverhaul.Creepers;
 import tech.thatgravyboat.creeperoverhaul.common.config.SpawningConfig;
 import tech.thatgravyboat.creeperoverhaul.common.entity.base.CreeperType;
@@ -29,11 +30,13 @@ public class CreeperTypes {
             .setAnimation(modLoc("animations/creeper.animation.json"))
             .addAfraidOf(EntityType.CAT)
             .addAfraidOf(EntityType.OCELOT)
+            .addReplacer(state -> state.is(Blocks.GRASS) || state.is(Blocks.FERN), random -> random.nextInt(1) == 0 ? Blocks.MELON.defaultBlockState() : null)
             .setDeathSounds(ModSounds.PLANT_DEATH)
             .setExplosionSounds(ModSounds.PLANT_EXPLOSION)
             .setHurtSounds(ModSounds.PLANT_HURT)
             .setPrimeSounds(ModSounds.PLANT_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowJungleCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType BAMBOO = new CreeperType.Builder()
@@ -42,17 +45,18 @@ public class CreeperTypes {
             .setChargedTexture(modLoc("textures/entity/armor/creeper_armor.png"))
             .setModel(modLoc("geo/bamboo.geo.json"))
             .setAnimation(modLoc("animations/bamboo.animation.json"))
-            .setMelee(9)
+            .addAfraidOf(EntityType.CAT)
+            .addAfraidOf(EntityType.OCELOT)
             .addAfraidOf(EntityType.PANDA)
             .addAttribute(Attributes.MAX_HEALTH, 15)
-            .addAttribute(Attributes.ATTACK_DAMAGE, 2)
-            .addAttribute("reach_distance", 2)
+            .addReplacer(state -> state.is(Blocks.GRASS) || state.is(Blocks.FERN), random -> random.nextInt(1) == 0 ? Blocks.BAMBOO.defaultBlockState() : null)
             .setDeathSounds(ModSounds.PLANT_DEATH)
             .setExplosionSounds(ModSounds.PLANT_EXPLOSION)
             .setHitSounds(ModSounds.PLANT_HIT)
             .setHurtSounds(ModSounds.PLANT_HURT)
             .setPrimeSounds(ModSounds.PLANT_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowBambooCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType DESERT = new CreeperType.Builder()
@@ -65,13 +69,16 @@ public class CreeperTypes {
             .setAnimation(modLoc("animations/creeper.animation.json"))
             .addAfraidOf(EntityType.CAT)
             .addAfraidOf(EntityType.OCELOT)
-            .addImmunity(DamageSource.CACTUS)
-            .addAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5)
+            //.addImmunity(DamageSources)
+            .addAttribute(Attributes.MAX_HEALTH, 30)
+            .addAttribute(Attributes.KNOCKBACK_RESISTANCE, 1)
+            .addReplacer(state -> state.is(Blocks.SAND) || state.is(Blocks.SANDSTONE), random -> random.nextInt(3) == 0 ? Blocks.CHISELED_SANDSTONE.defaultBlockState() : null)
             .setDeathSounds(ModSounds.SAND_DEATH)
             .setExplosionSounds(ModSounds.SAND_EXPLOSION)
             .setHurtSounds(ModSounds.SAND_HURT)
             .setPrimeSounds(ModSounds.SAND_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowDesertCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType BADLANDS = new CreeperType.Builder()
@@ -84,14 +91,16 @@ public class CreeperTypes {
             .setAnimation(modLoc("animations/creeper.animation.json"))
             .addAfraidOf(EntityType.CAT)
             .addAfraidOf(EntityType.OCELOT)
-            .addImmunity(DamageSource.CACTUS)
+            //.addImmunity(DamageSource.CACTUS)
             .addAttribute(Attributes.MAX_HEALTH, 30)
             .addAttribute(Attributes.KNOCKBACK_RESISTANCE, 1)
+            .addReplacer(state -> state.is(Blocks.RED_SANDSTONE) || state.is(Blocks.RED_SAND), random -> random.nextInt(3) == 0 ? Blocks.CHISELED_RED_SANDSTONE.defaultBlockState() : null)
             .setDeathSounds(ModSounds.SAND_DEATH)
             .setExplosionSounds(ModSounds.SAND_EXPLOSION)
             .setHurtSounds(ModSounds.SAND_HURT)
             .setPrimeSounds(ModSounds.SAND_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowBadlandsCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType HILLS = new CreeperType.Builder()
@@ -101,12 +110,14 @@ public class CreeperTypes {
             .setModel(modLoc("geo/hills.geo.json"))
             .setAnimation(modLoc("animations/creeper.animation.json"))
             .addAttribute(Attributes.MAX_HEALTH, 30)
-            .addAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5)
+            .addAttribute(Attributes.KNOCKBACK_RESISTANCE, 1)
+            .addReplacer(state -> state.is(Blocks.GRASS) || state.is(Blocks.FERN), random -> random.nextInt(1) == 0 ? Blocks.PUMPKIN.defaultBlockState() : null)
             .setDeathSounds(ModSounds.STONE_DEATH)
             .setExplosionSounds(ModSounds.STONE_EXPLOSION)
             .setHurtSounds(ModSounds.STONE_HURT)
             .setPrimeSounds(ModSounds.STONE_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowHillsCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType SAVANNAH = new CreeperType.Builder()
@@ -115,16 +126,18 @@ public class CreeperTypes {
             .setChargedTexture(modLoc("textures/entity/armor/creeper_armor_3.png"))
             .setModel(modLoc("geo/savannah.geo.json"))
             .setAnimation(modLoc("animations/savannah.animation.json"))
-            .setMelee(5)
-            .addAttribute(Attributes.MAX_HEALTH, 25)
-            .addAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5)
-            .addAttribute(Attributes.ATTACK_DAMAGE, 3)
+            .addAfraidOf(EntityType.CAT)
+            .addAfraidOf(EntityType.OCELOT)
+            .addAttribute(Attributes.MAX_HEALTH, 30)
+            .addAttribute(Attributes.KNOCKBACK_RESISTANCE, 1)
+            .addReplacer(state -> state.is(Blocks.GRASS_BLOCK) || state.is(Blocks.DIRT), random -> random.nextInt(3) == 0 ? Blocks.COARSE_DIRT.defaultBlockState() : null)
             .setDeathSounds(ModSounds.WOOD_DEATH)
             .setExplosionSounds(ModSounds.WOOD_EXPLOSION)
             .setHurtSounds(ModSounds.WOOD_HURT)
             .setHitSounds(ModSounds.WOOD_HIT)
             .setPrimeSounds(ModSounds.WOOD_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowSavannahCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType MUSHROOM = new CreeperType.Builder()
@@ -133,13 +146,13 @@ public class CreeperTypes {
             .setChargedTexture(modLoc("textures/entity/armor/creeper_armor_4.png"))
             .setModel(modLoc("geo/mushroom.geo.json"))
             .setAnimation(modLoc("animations/creeper.animation.json"))
-            .addPotionsWhenDying(new MobEffectInstance(MobEffects.POISON, 100, 1))
             .addReplacer(state -> state.is(Blocks.GRASS_BLOCK) || state.is(Blocks.DIRT), random -> random.nextInt(3) == 0 ? Blocks.MYCELIUM.defaultBlockState() : null)
             .setDeathSounds(ModSounds.PLANT_DEATH)
             .setExplosionSounds(ModSounds.PLANT_EXPLOSION)
             .setHurtSounds(ModSounds.PLANT_HURT)
             .setPrimeSounds(ModSounds.PLANT_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowMushroomCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType SWAMP = new CreeperType.Builder()
@@ -151,11 +164,13 @@ public class CreeperTypes {
             .addAfraidOf(EntityType.CAT)
             .addAfraidOf(EntityType.OCELOT)
             .addAttribute("swim_speed", 2)
+            .addReplacer(state -> state.is(Blocks.GRASS_BLOCK) || state.is(Blocks.DIRT), random -> random.nextInt(3) == 0 ? Blocks.MUD.defaultBlockState() : null)
             .setDeathSounds(ModSounds.PLANT_DEATH)
             .setExplosionSounds(ModSounds.PLANT_EXPLOSION)
             .setHurtSounds(ModSounds.PLANT_HURT)
             .setPrimeSounds(ModSounds.PLANT_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowSwampCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType DRIPSTONE = new CreeperType.Builder()
@@ -166,12 +181,15 @@ public class CreeperTypes {
             .setAnimation(modLoc("animations/creeper.animation.json"))
             .addAfraidOf(EntityType.CAT)
             .addAfraidOf(EntityType.OCELOT)
-            .addAttribute(Attributes.MAX_HEALTH, 12)
+            .addAttribute(Attributes.MAX_HEALTH, 30)
+            .addAttribute(Attributes.KNOCKBACK_RESISTANCE, 1)
+            .addReplacer(state -> state.is(Blocks.STONE) || state.is(Blocks.TUFF), random -> random.nextInt(3) == 0 ? Blocks.DRIPSTONE_BLOCK.defaultBlockState() : null)
             .setDeathSounds(ModSounds.STONE_DEATH)
             .setExplosionSounds(ModSounds.STONE_EXPLOSION)
             .setHurtSounds(ModSounds.STONE_HURT)
             .setPrimeSounds(ModSounds.STONE_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowDripstoneCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType CAVE = new CreeperType.Builder()
@@ -182,14 +200,15 @@ public class CreeperTypes {
             .setAnimation(modLoc("animations/creeper.animation.json"))
             .addAfraidOf(EntityType.CAT)
             .addAfraidOf(EntityType.OCELOT)
-            .addAttribute(Attributes.MAX_HEALTH, 25)
-            .addAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5)
-            .addReplacer(state -> state.is(Blocks.STONE), random -> random.nextInt(100) == 0 ? Blocks.COAL_ORE.defaultBlockState() : null)
+            .addAttribute(Attributes.MAX_HEALTH, 30)
+            .addAttribute(Attributes.KNOCKBACK_RESISTANCE, 1)
+            .addReplacer(state -> state.is(Blocks.STONE), random -> random.nextInt(3) == 0 ? Blocks.COBBLESTONE.defaultBlockState() : null)
             .setDeathSounds(ModSounds.STONE_DEATH)
             .setExplosionSounds(ModSounds.STONE_EXPLOSION)
             .setHurtSounds(ModSounds.STONE_HURT)
             .setPrimeSounds(ModSounds.STONE_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowCaveCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType DARK_OAK = new CreeperType.Builder()
@@ -200,12 +219,13 @@ public class CreeperTypes {
             .setAnimation(modLoc("animations/creeper.animation.json"))
             .addAfraidOf(EntityType.CAT)
             .addAfraidOf(EntityType.OCELOT)
-            .addInflictingPotion(new MobEffectInstance(MobEffects.BLINDNESS, 100, 0))
+            .addReplacer(state -> state.is(Blocks.GRASS_BLOCK) || state.is(Blocks.DIRT), random -> random.nextInt(3) == 0 ? Blocks.MOSSY_COBBLESTONE.defaultBlockState() : null)
             .setDeathSounds(ModSounds.WOOD_DEATH)
             .setExplosionSounds(ModSounds.WOOD_EXPLOSION)
             .setHurtSounds(ModSounds.WOOD_HURT)
             .setPrimeSounds(ModSounds.WOOD_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowDarkOakCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType SPRUCE = new CreeperType.Builder()
@@ -222,6 +242,7 @@ public class CreeperTypes {
             .setHurtSounds(ModSounds.STONE_HURT)
             .setPrimeSounds(ModSounds.STONE_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowSpruceCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType BEACH = new CreeperType.Builder()
@@ -232,14 +253,16 @@ public class CreeperTypes {
             .setAnimation(modLoc("animations/creeper.animation.json"))
             .addAfraidOf(EntityType.CAT)
             .addAfraidOf(EntityType.OCELOT)
-            .addImmunity(DamageSource.DROWN)
+            //.addImmunity(DamageSource.DROWN)
             .addAttribute(Attributes.MAX_HEALTH, 15)
             .addAttribute("swim_speed", 2)
+            .addReplacer(state -> state.is(Blocks.GRASS_BLOCK) || state.is(Blocks.DIRT), random -> random.nextInt(3) == 0 ? Blocks.SAND.defaultBlockState() : null)
             .setDeathSounds(ModSounds.SAND_DEATH)
             .setExplosionSounds(ModSounds.SAND_EXPLOSION)
             .setHurtSounds(ModSounds.SAND_HURT)
             .setPrimeSounds(ModSounds.SAND_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowBeachCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType SNOWY = new CreeperType.Builder()
@@ -248,10 +271,15 @@ public class CreeperTypes {
             .setChargedTexture(modLoc("textures/entity/armor/creeper_armor.png"))
             .setModel(modLoc("geo/snowy.geo.json"))
             .setAnimation(modLoc("animations/snowy.animation.json"))
-            .setMelee(5)
-            .addAttribute(Attributes.ATTACK_DAMAGE, 4)
-            .addAttackingEntities(Stray.class)
+            .addAfraidOf(EntityType.CAT)
+            .addAfraidOf(EntityType.OCELOT)
+            .addReplacer(state -> state.is(Blocks.GRASS_BLOCK) || state.is(Blocks.DIRT), random -> random.nextInt(3) == 0 ? Blocks.POWDER_SNOW.defaultBlockState() : null)
+            .setDeathSounds(ModSounds.PLANT_DEATH)
+            .setExplosionSounds(ModSounds.PLANT_EXPLOSION)
+            .setHurtSounds(ModSounds.PLANT_HURT)
+            .setPrimeSounds(ModSounds.PLANT_PRIME)
             .setCanSpawn(() -> SpawningConfig.allowSnowyCreeperSpawning)
+            .addAttackingEntities(Player.class)
             .build();
 
     public static final CreeperType OCEAN = new CreeperType.Builder()


### PR DESCRIPTION
Hi, I just cooked this up for funzies. I have tested these changes extensively and found no issues.

Essentially:

All creepers are hostile+explode as an attack (including the snowy creeper.)
No creepers melee or apply effects.
All creepers use .addReplacer.
All creepers made of rock have consistent higher health and knockback resistance.
All creepers are afraid of cats and ocelots.
The funni pufferfish creeper was left alone, they chillin.
Why?

I personally find it odd how some creepers are just friendly and some melee rather than explode. I do acknowledge that there is a texture pack alternative to have them all function like creepers but I chose to write this to take advantage of the replacer function and the ability to make some creepers a bit tougher (rocks).

I'm sure other people would like this version of the mod but if you would prefer to keep their original set ups, you can also make this a separate branch and release them as a separate name on sites. If you do release this then plz credit me <3